### PR TITLE
encoded all strings passed to C library utf_8

### DIFF
--- a/acspy/acsc.py
+++ b/acspy/acsc.py
@@ -226,6 +226,8 @@ def getLastError():
 
 def runBuffer(hcomm, buffno, label=None, wait=SYNCHRONOUS):
     """Runs a buffer in the controller."""
+    if label is not None:
+        label=label.encode(encoding='utf_8', errors='strict')
     acs.acsc_RunBuffer(hcomm, int32(buffno), label, wait)
 
 def stopBuffer(hcomm, buffno, wait=SYNCHRONOUS):
@@ -244,13 +246,13 @@ def halt(hcomm, axis, wait=SYNCHRONOUS):
 
 def declareVariable(hcomm, vartype, varname, wait=SYNCHRONOUS):
     """Declare a variable in the controller."""
-    acs.acsc_DeclareVariable(hcomm, vartype, varname, wait)
+    acs.acsc_DeclareVariable(hcomm, vartype, varname.encode(encoding='utf_8', errors='strict'), wait)
 
 def readInteger(hcomm, buffno, varname, from1=None, to1=None, from2=None,
                 to2=None, wait=SYNCHRONOUS):
     """Reads an integer(s) in the controller."""
     intread = ctypes.c_int()
-    acs.acsc_ReadInteger(hcomm, buffno, varname, from1, to1, from2, to2,
+    acs.acsc_ReadInteger(hcomm, buffno, varname.encode(encoding='utf_8', errors='strict'), from1, to1, from2, to2,
                          p(intread), wait)
     return intread.value
 
@@ -258,7 +260,7 @@ def writeInteger(hcomm, variable, val_to_write, nbuff=NONE, from1=NONE,
                  to1=NONE, from2=NONE, to2=NONE, wait=SYNCHRONOUS):
     """Writes an integer variable to the controller."""
     val = ctypes.c_int(val_to_write)
-    acs.acsc_WriteInteger(hcomm, nbuff, variable, from1, to1,
+    acs.acsc_WriteInteger(hcomm, nbuff, variable.encode(encoding='utf_8', errors='strict'), from1, to1,
                  from2, to2, p(val), wait)
 
 def readReal(hcomm, buffno, varname, from1=NONE, to1=NONE, from2=NONE,
@@ -273,7 +275,7 @@ def readReal(hcomm, buffno, varname, from1=NONE, to1=NONE, from2=NONE,
     else:
         values = double()
         pointer = byref(values)
-    acs.acsc_ReadReal(hcomm, buffno, varname, from1, to1, from2, to2,
+    acs.acsc_ReadReal(hcomm, buffno, varname.encode(encoding='utf_8', errors='strict'), from1, to1, from2, to2,
                       pointer, wait)
     if from1 != NONE:
         return values
@@ -284,7 +286,7 @@ def writeReal(hcomm, varname, val_to_write, nbuff=NONE, from1=NONE, to1=NONE,
               from2=NONE, to2=NONE, wait=SYNCHRONOUS):
     """Writes a real value to the controller."""
     val = ctypes.c_double(val_to_write)
-    acs.acsc_WriteReal(hcomm, nbuff, varname, from1, to1,
+    acs.acsc_WriteReal(hcomm, nbuff, varname.encode(encoding='utf_8', errors='strict'), from1, to1,
                        from2, to2, p(val), wait)
 
 def uploadDataFromController(hcomm, src, srcname, srcnumformat, from1, to1,
@@ -296,13 +298,13 @@ def uploadDataFromController(hcomm, src, srcname, srcnumformat, from1, to1,
 
 def loadBuffer(hcomm, buffnumber, program, count=512, wait=SYNCHRONOUS):
     """Load a buffer into the ACS controller."""
-    prgbuff = ctypes.create_string_buffer(str(program).encode(), count)
+    prgbuff = ctypes.create_string_buffer(str(program).encode(encoding='utf_8', errors='strict'), count)
     rv = acs.acsc_LoadBuffer(hcomm, buffnumber, byref(prgbuff), count, wait)
     errorHandling(rv)
 
 
 def loadBuffersFromFile(hcomm, filename, wait=SYNCHRONOUS):
-    rv = acs.acsc_LoadBuffersFromFile(hcomm, filename, wait)
+    rv = acs.acsc_LoadBuffersFromFile(hcomm, filename.encode(encoding='utf_8', errors='strict'), wait)
     errorHandling(rv)
 
 


### PR DESCRIPTION
If a string is passed to C library it's encoded to UTF8. Unicode created problems with Python 3.
"string".encode(encoding='utf_8', errors='strict')