### PR TITLE
Add acsc_GetJerk, acsc_GetTargetPosition, and acsc_WaitMotionEnd Functions

### DIFF
--- a/acspy/__init__.py
+++ b/acspy/__init__.py
@@ -1,3 +1,3 @@
 """A package for working with ACS motion controllers in Python."""
 
-__version__ = "0.0.8"
+__version__ = "0.0.9"

--- a/acspy/acsc.py
+++ b/acspy/acsc.py
@@ -239,6 +239,12 @@ def setJerk(hcomm, axis: int, jerk: float, wait=SYNCHRONOUS):
     """Defines a value of motion jerk."""
     call_acsc(acs.acsc_SetJerk, hcomm, axis, double(jerk), wait)
 
+def getJerk(hcomm, axis: int, wait=SYNCHRONOUS):
+    """Returns current jerk for specified axis."""
+    val = double()
+    call_acsc(acs.acsc_GetJerk, hcomm, axis, byref(val), wait)
+    return val.value
+    
 
 def setRPosition(hcomm, axis: int, rpos: float, wait=SYNCHRONOUS):
     """Asigns a current value of reference position."""
@@ -333,7 +339,13 @@ def getFPosition(hcomm, axis: int, wait=SYNCHRONOUS):
     call_acsc(acs.acsc_GetFPosition, hcomm, axis, byref(fposition), wait)
     fposition = fposition.value
     return fposition
-
+    
+def getTPosition(hcomm, axis: int, wait=SYNCHRONOUS):
+    """Retrieves an instant value of the motor feedback position."""
+    tposition = ctypes.c_double()
+    call_acsc(acs.acsc_GetTargetPosition, hcomm, axis, byref(tposition), wait)
+    tposition = tposition.value
+    return tposition
 
 def registerEmergencyStop():
     """Register the software emergency stop."""
@@ -405,6 +417,9 @@ def waitCommutated(hcomm, axis: int, timeout=INFINITE):
         acs.acsc_WaitMotorCommutated, hcomm, int32(axis), 1, int32(timeout)
     )
 
+def WaitMotionEnd(hcomm, axis : int, timeout=INFINITE):
+    """The function waits for the end of a motion."""
+    call_acsc(acs.acsc_WaitMotionEnd , hcomm, int32(axis), int32(timeout))
 
 def disable(hcomm, axis: int, wait=SYNCHRONOUS):
     """The function shuts off a motor."""

--- a/acspy/acsc.py
+++ b/acspy/acsc.py
@@ -421,7 +421,7 @@ def waitCommutated(hcomm, axis: int, timeout=INFINITE):
     )
 
 
-def WaitMotionEnd(hcomm, axis: int, timeout=INFINITE):
+def waitMotionEnd(hcomm, axis: int, timeout=INFINITE):
     """The function waits for the end of a motion."""
     call_acsc(acs.acsc_WaitMotionEnd, hcomm, int32(axis), int32(timeout))
 

--- a/acspy/acsc.py
+++ b/acspy/acsc.py
@@ -341,7 +341,7 @@ def getFPosition(hcomm, axis: int, wait=SYNCHRONOUS):
     return fposition
     
 def getTPosition(hcomm, axis: int, wait=SYNCHRONOUS):
-    """Retrieves an instant value of the motor feedback position."""
+    """Retrieves an instant value of the motor target position."""
     tposition = ctypes.c_double()
     call_acsc(acs.acsc_GetTargetPosition, hcomm, axis, byref(tposition), wait)
     tposition = tposition.value

--- a/acspy/acsc.py
+++ b/acspy/acsc.py
@@ -448,12 +448,6 @@ def getRPosition(hcomm, axis: int, wait=SYNCHRONOUS):
     return pos.value
 
 
-def getFPosition(hcomm, axis: int, wait=SYNCHRONOUS):
-    pos = double()
-    call_acsc(acs.acsc_GetFPosition, hcomm, axis, byref(pos), wait)
-    return pos.value
-
-
 def getRVelocity(hcomm, axis: int, wait=SYNCHRONOUS):
     rvel = double()
     call_acsc(acs.acsc_GetRVelocity, hcomm, axis, byref(rvel), wait)

--- a/acspy/acsc.py
+++ b/acspy/acsc.py
@@ -239,12 +239,13 @@ def setJerk(hcomm, axis: int, jerk: float, wait=SYNCHRONOUS):
     """Defines a value of motion jerk."""
     call_acsc(acs.acsc_SetJerk, hcomm, axis, double(jerk), wait)
 
+
 def getJerk(hcomm, axis: int, wait=SYNCHRONOUS):
     """Returns current jerk for specified axis."""
     val = double()
     call_acsc(acs.acsc_GetJerk, hcomm, axis, byref(val), wait)
     return val.value
-    
+
 
 def setRPosition(hcomm, axis: int, rpos: float, wait=SYNCHRONOUS):
     """Asigns a current value of reference position."""
@@ -339,13 +340,15 @@ def getFPosition(hcomm, axis: int, wait=SYNCHRONOUS):
     call_acsc(acs.acsc_GetFPosition, hcomm, axis, byref(fposition), wait)
     fposition = fposition.value
     return fposition
-    
+
+
 def getTPosition(hcomm, axis: int, wait=SYNCHRONOUS):
     """Retrieves an instant value of the motor target position."""
     tposition = ctypes.c_double()
     call_acsc(acs.acsc_GetTargetPosition, hcomm, axis, byref(tposition), wait)
     tposition = tposition.value
     return tposition
+
 
 def registerEmergencyStop():
     """Register the software emergency stop."""
@@ -417,9 +420,11 @@ def waitCommutated(hcomm, axis: int, timeout=INFINITE):
         acs.acsc_WaitMotorCommutated, hcomm, int32(axis), 1, int32(timeout)
     )
 
-def WaitMotionEnd(hcomm, axis : int, timeout=INFINITE):
+
+def WaitMotionEnd(hcomm, axis: int, timeout=INFINITE):
     """The function waits for the end of a motion."""
-    call_acsc(acs.acsc_WaitMotionEnd , hcomm, int32(axis), int32(timeout))
+    call_acsc(acs.acsc_WaitMotionEnd, hcomm, int32(axis), int32(timeout))
+
 
 def disable(hcomm, axis: int, wait=SYNCHRONOUS):
     """The function shuts off a motor."""


### PR DESCRIPTION
I have been working with ACSpy for a while and I notice that these functions are not added yet. 
This pull request adds three new functions to ACSpy:
- acsc_GetJerk
Retrieves the configured jerk value for the specified axis.
- acsc_GetTargetPosition
Retrieves an instant value of the motor Target position.
- acsc_WaitMotionEnd
Waits until motion on the specified axis is complete.

These functions help users monitor motion parameters more easily and control the flow of operations